### PR TITLE
Support for custom coloring

### DIFF
--- a/projects/ngx-notification-msg/src/lib/ngx-notification-msg.component.ts
+++ b/projects/ngx-notification-msg/src/lib/ngx-notification-msg.component.ts
@@ -8,8 +8,15 @@ import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, EventEmitter, I
 export class NgxNotificationMsgComponent implements OnInit, AfterViewInit {
     private static readonly DELAY_ON_CLICK = 400;
 
+    statusToClass = {
+        [NgxNotificationStatusMsg.NONE]: '',
+        [NgxNotificationStatusMsg.INFO]: '#0067FF',
+        [NgxNotificationStatusMsg.FAILURE]: '#FE355A',
+        [NgxNotificationStatusMsg.SUCCESS]: '#00CC69'
+    };
     @Input() status: NgxNotificationStatusMsg = NgxNotificationStatusMsg.NONE;
     @Input() direction: NgxNotificationDirection = NgxNotificationDirection.TOP;
+    @Input() color: string = this.statusToClass[this.status];
     @Input() displayProgressBar = true;
     @Input() displayIcon = true;
     @Input() header: string;
@@ -22,12 +29,6 @@ export class NgxNotificationMsgComponent implements OnInit, AfterViewInit {
 
     componentState: NgxNotificationMsgComponentState = NgxNotificationMsgComponentState.CLOSE;
     componentStates = NgxNotificationMsgComponentState;
-    statusToClass = {
-        [NgxNotificationStatusMsg.NONE]: '',
-        [NgxNotificationStatusMsg.INFO]: '#0067FF',
-        [NgxNotificationStatusMsg.FAILURE]: '#FE355A',
-        [NgxNotificationStatusMsg.SUCCESS]: '#00CC69'
-    };
     readonly none = 'NONE';
 
     private closeTimeout;
@@ -87,7 +88,7 @@ export class NgxNotificationMsgComponent implements OnInit, AfterViewInit {
 
     private initTheme(): void {
         this.element.nativeElement.style.setProperty('--ngx-notification-msg-delay', `${this.delay}ms`);
-        this.element.nativeElement.style.setProperty('--ngx-notification-msg-color', this.statusToClass[this.status]);
+        this.element.nativeElement.style.setProperty('--ngx-notification-msg-color', this.color);
     }
 
     private getDefaultPosition(): INgxNotificationPosition {
@@ -177,4 +178,5 @@ export interface INgxNotificationMsgConfig {
     displayIcon?: boolean;
     displayProgressBar?: boolean;
     closeable?: boolean;
+    color?: string;
 }

--- a/projects/ngx-notification-msg/src/lib/ngx-notification-msg.component.ts
+++ b/projects/ngx-notification-msg/src/lib/ngx-notification-msg.component.ts
@@ -88,7 +88,7 @@ export class NgxNotificationMsgComponent implements OnInit, AfterViewInit {
 
     private initTheme(): void {
         this.element.nativeElement.style.setProperty('--ngx-notification-msg-delay', `${this.delay}ms`);
-        this.element.nativeElement.style.setProperty('--ngx-notification-msg-color', this.color);
+        this.element.nativeElement.style.setProperty('--ngx-notification-msg-color', this.color || this.statusToClass[this.status]);
     }
 
     private getDefaultPosition(): INgxNotificationPosition {

--- a/projects/ngx-notification-msg/src/lib/ngx-notification-msg.html
+++ b/projects/ngx-notification-msg/src/lib/ngx-notification-msg.html
@@ -7,7 +7,7 @@
     <div class="ngx_notification-msg-icon-wrapper"
          *ngIf="status !== none && displayIcon">
         <svg>
-            <use [attr.xlink:href]="statusToClass[status]"/>
+            <use [attr.xlink:href]="status ? '#' + status : ''"/>
         </svg>
     </div>
     <div class="ngx_notification-msg-content">
@@ -29,19 +29,19 @@
 </div>
 
 <svg display="none">
-    <symbol width="24" height="24" viewBox="0 0 32 32" id="00CC69">
+    <symbol width="24" height="24" viewBox="0 0 32 32" id="SUCCESS">
         <path d="M16,0 C24.836556,0 32,7.163444 32,16 C32,24.836556 24.836556,32 16,32 C7.163444,32 0,24.836556 0,16 C0,7.163444 7.163444,0 16,0 Z M23.6,9.6 L13,20.2 L8.8,16 L7.4,17.4 L13,23 L25,11 L23.6,9.6 Z"/>
     </symbol>
 </svg>
 
 <svg display="none">
-    <symbol width="24" height="24" viewBox="0 0 32 32" id="FE355A">
+    <symbol width="24" height="24" viewBox="0 0 32 32" id="FAILURE">
         <path d="M16,0 C24.836556,0 32,7.163444 32,16 C32,24.836556 24.836556,32 16,32 C7.163444,32 0,24.836556 0,16 C0,7.163444 7.163444,0 16,0 Z M21.59,9 L16,14.59 L10.41,9 L9,10.41 L14.59,16 L9,21.59 L10.41,23 L16,17.41 L21.59,23 L23,21.59 L17.41,16 L23,10.41 L21.59,9 Z"/>
     </symbol>
 </svg>
 
 <svg display="none">
-    <symbol width="24" height="24" viewBox="0 0 32 32" id="0067FF">
+    <symbol width="24" height="24" viewBox="0 0 32 32" id="INFO">
         <path d="M16,0 C24.836556,0 32,7.163444 32,16 C32,24.836556 24.836556,32 16,32 C7.163444,32 0,24.836556 0,16 C0,7.163444 7.163444,0 16,0 Z M17,12 L15,12 L15,24 L17,24 L17,12 Z M17,8 L15,8 L15,10 L17,10 L17,8 Z"/>
     </symbol>
 </svg>


### PR DESCRIPTION
Slight changes to the ngx-notification-msg component HTML and TS files to support a color value to be provided, while still defaulting to the existing colors for each status type. The HTML change was not necessarily required since the default color values still exist but I thought it was more readable like so.

Note: I did not test these changes, in fact I did these changes quickly on Github itself.